### PR TITLE
Add score to Pong data type

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -105,6 +105,7 @@ initialize = do
         initialState = Pong { _ball           = initialBall
                             , _paddles        = (leftPaddle, rightPaddle)
                             , _playFieldSpecs = playFieldSpecs
+                            , _score          = (0, 0)
                             }
     --putStrLn $ show (take 10 (states ((1,80),(1,25)) initialState))
     evalStateT loop initialState

--- a/src/Pong.hs
+++ b/src/Pong.hs
@@ -29,6 +29,7 @@ data Paddle = Paddle { _position :: Point
 data Pong = Pong { _ball :: Ball
                  , _paddles :: (Paddle, Paddle)
                  , _playFieldSpecs :: PlayFieldSpecs
+                 , _score :: (Int, Int)
                  } deriving (Eq, Show)
 
 data ColorRGB = RGB { _red :: Int
@@ -95,4 +96,9 @@ playFieldWidth = playFieldSpecs . size . width
 playFieldHeight :: Lens' Pong Int
 playFieldHeight = playFieldSpecs . size . height
 
+player1Score :: Lens' Pong Int
+player1Score = score . _1
+
+player2Score :: Lens' Pong Int
+player2Score = score . _2
 


### PR DESCRIPTION
This just adds the score to the Pong data type but does not modify the score if the ball reaches the left or right hand side of the screen. 

Maybe we can discuss about how best that should be implemented since it will likely require changes to `boundary` and `checkBounds`? Either `boundary` needs to be in `State Pong b` or it can be inlined in `checkBounds`. Essentially, player1 scores if `x <= 1` and player2 scores if `x >= xLim`, but also instead of bouncing, the state of the game should be update to start the next serve.